### PR TITLE
Add himp info in agenda list and fix filter reset

### DIFF
--- a/resources/js/features/dashboard/achievements/components/filter-achievements.tsx
+++ b/resources/js/features/dashboard/achievements/components/filter-achievements.tsx
@@ -167,7 +167,7 @@ export default function FilterAchievements() {
 				<Button
 					className="bg-[#F2F4F7] hover:bg-[#F2F4F7]/80 text-[#101828] rounded-full font-medium text-sm"
 					onClick={() => {
-						setFilter({ search: "", set_type: undefined, year: undefined });
+						setFilter({ search: "", set_type: undefined, year: "" });
 						router.get(
 							window.location.pathname,
 							{

--- a/resources/js/features/dashboard/agendas/components/filter-agendas.tsx
+++ b/resources/js/features/dashboard/agendas/components/filter-agendas.tsx
@@ -167,7 +167,7 @@ export default function FilterAgendas() {
 				<Button
 					className="bg-[#F2F4F7] hover:bg-[#F2F4F7]/80 text-[#101828] rounded-full font-medium text-sm"
 					onClick={() => {
-						setFilter({ search: "", set_type: undefined, year: undefined });
+						setFilter({ search: "", set_type: undefined, year: "" });
 						router.get(
 							window.location.pathname,
 							{

--- a/resources/js/features/dashboard/home/components/event-calendar-card.tsx
+++ b/resources/js/features/dashboard/home/components/event-calendar-card.tsx
@@ -1,5 +1,6 @@
 import { buttonVariants } from "@/shared/components/ui/button";
 import { Calendar } from "@/shared/components/ui/calendar";
+import { AgendaSetTypeMap } from "@/shared/lib/enums";
 import { cn } from "@/shared/lib/utils";
 import type { Agenda } from "@/shared/types";
 import { router } from "@inertiajs/react";
@@ -86,7 +87,7 @@ export default function EventCalendarCard({ agendas }: Props) {
 							key={agenda.id}
 							className="bg-[#F2F4F7] relative rounded-xl p-4 pl-6 text-sm after:bg-[#17C3AF] after:absolute after:inset-y-4 after:left-3 after:w-0.5 after:rounded-full"
 						>
-							<div className="font-bold">{agenda.name}</div>
+							<div className="font-bold">{`${agenda.name} (${AgendaSetTypeMap[agenda.set_type]})`}</div>
 							<div className="text-[#667085] text-sm">
 								{date?.toLocaleDateString([], {
 									weekday: "long",


### PR DESCRIPTION
This pull request includes updates to improve filtering functionality and enhance the display of agenda information in the dashboard components. The changes primarily focus on refining filter behavior and adding contextual details to agenda names.

### Filtering functionality updates:

* [`resources/js/features/dashboard/achievements/components/filter-achievements.tsx`](diffhunk://#diff-e6588cb7f051fedb6ad0a01fe7941ebc4b0834756bf776a373189956ff1d13f6L170-R170): Updated the `setFilter` function to set the `year` property to an empty string instead of `undefined` for better consistency in filter initialization.
* [`resources/js/features/dashboard/agendas/components/filter-agendas.tsx`](diffhunk://#diff-9efcbab1396c9d9eed0cac6c290780ec0fea2a0937fa6049f95e9ec6b539518aL170-R170): Made the same adjustment to the `setFilter` function as above, ensuring uniform behavior across filtering components.

### Enhancements to agenda display:

* [`resources/js/features/dashboard/home/components/event-calendar-card.tsx`](diffhunk://#diff-e47229273e0dbbb42ab709e03ed9137e10f339607804dae61df343af113ffdf3R3): Imported `AgendaSetTypeMap` to provide a mapping for agenda set types.
* [`resources/js/features/dashboard/home/components/event-calendar-card.tsx`](diffhunk://#diff-e47229273e0dbbb42ab709e03ed9137e10f339607804dae61df343af113ffdf3L89-R90): Modified the agenda name display to include the set type in parentheses, offering additional context for users viewing the event calendar.